### PR TITLE
Fix Gist export.

### DIFF
--- a/jupyter-notebook-gist/create_gist.py
+++ b/jupyter-notebook-gist/create_gist.py
@@ -115,7 +115,7 @@ class BaseHandler(IPythonHandler):
 
     def get_notebook_filename(self, nb_path):
 
-        if not isinstance(nb_path, str) or len(nb_path) == 0:
+        if not (isinstance(nb_path, str) or isinstance(nb_path, unicode)) or len(nb_path) == 0:
             raise_error("Problem with notebook file name")
 
         # Extract file names given path to notebook
@@ -132,7 +132,7 @@ class BaseHandler(IPythonHandler):
 
     def get_notebook_contents(self, nb_path):
 
-        if not isinstance(nb_path, str) or len(nb_path) == 0:
+        if not (isinstance(nb_path, str) or isinstance(nb_path, unicode)) or len(nb_path) == 0:
             raise_error("Couldn't export notebook contents")
 
         # Extract file contents given the path to the notebook


### PR DESCRIPTION
The notebook path is a `unicode` rather than a `str`. This is on the following setup:
- Ubuntu 15.10 x64
- Python 2.7.10
- Jupyter 4.0.6

Without this patch, exporting fails with `ERROR: Problem with notebook file name`. With it, it works fine.
